### PR TITLE
Fix link to homepage in gemspec

### DIFF
--- a/6to5-source.gemspec.erb
+++ b/6to5-source.gemspec.erb
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.date = Time.at(<%= date %>)
 
   s.summary = "6to5 source"
-  s.homepage = "https://github.com/6to5/ruby-6to5"
+  s.homepage = "https://github.com/6to5/6to5-ruby"
   s.license = "MIT"
 
   s.files = [

--- a/6to5.gemspec
+++ b/6to5.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name    = '6to5'
   s.version = ES6to5::VERSION
 
-  s.homepage    = "https://github.com/6to5/ruby-6to5"
+  s.homepage    = "https://github.com/6to5/6to5-ruby"
   s.summary     = "Ruby 6to5 Compiler"
   s.description = <<-EOS
     Ruby 6to5 is a bridge to the JS 6to5 compiler.


### PR DESCRIPTION
Now, this gem is named as '6to5-ruby', not 'ruby-6to5'.