### PR TITLE
Make ruby-6to5 work with therubyracer and javascriptcore

### DIFF
--- a/6to5.gemspec
+++ b/6to5.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'execjs', '~> 2.0'
   s.add_development_dependency 'rake', '~> 10.4'
   s.add_development_dependency 'minitest', '~> 5.5'
+  s.add_development_dependency 'therubyracer', '~> 0.12'
 
   s.authors = ['Joshua Peek']
   s.email   = 'josh@joshpeek.com'

--- a/lib/6to5.rb
+++ b/lib/6to5.rb
@@ -24,7 +24,7 @@ module ES6to5
     end
 
     def self.context
-      @context ||= ExecJS.compile(File.read(path))
+      @context ||= ExecJS.compile('var self = this;' + File.read(path))
     end
   end
 

--- a/test/test_6to5.rb
+++ b/test/test_6to5.rb
@@ -4,6 +4,10 @@ require '6to5'
 class Test6to5 < MiniTest::Test
   NO_RUNTIME = %w( 3.0 3.1 3.2 ).any? { |v| ES6to5.version.start_with?(v) }
 
+  def setup
+    ExecJS.runtime = ExecJS::Runtimes.autodetect
+  end
+
   def test_source_constants
     assert ES6to5::Source::VERSION
     assert ES6to5::Source::DATE
@@ -51,6 +55,14 @@ class Test6to5 < MiniTest::Test
 
     code = ES6to5.transform("return (function f(x, y = 12) { return x + y; })(3)")["code"]
     assert_equal 15, ExecJS.exec(code)
+  end
+
+  def test_every_runtime
+    ExecJS::Runtimes.runtimes.reject(&:deprecated?).find_all(&:available?).each do |runtime|
+      ExecJS.runtime = runtime
+      # just make sure it doesn't throw an error
+      ES6to5.transform("return [0, 2, 4].map(v => v + 1)")["code"]
+    end
   end
 
   def test_transform_options


### PR DESCRIPTION
Currently, this gem doesn't work if therubyracer or JavascriptCore is selected by ExecJS as the runtime.

How to reproduce:

```
$ git clone https://github.com/6to5/ruby-6to5
$ cd ruby-6to5
$ bundle install
$ bundle exec rake test # passes
# add "gem 'therubyracer', platforms: :ruby" to Gemfile
$ bundle install
$ bundle exec rake test #fails
# lots of these errors: "V8::Error: Cannot set property 'to5' of undefined"

# if you are on a mac
$ EXECJS_RUNTIME=JavaScriptCore bundle exec rake test
# lots of these errors: "ExecJS::ProgramError: TypeError: undefined is not an object (evaluating 'f.to5=e()')"
```

**Explanation**

6to5-source-3.3.4/lib/6to5.js - Line 1 : Columns 153 to 273 looks like this:

`var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.to5=e()`

First, it checks for commonJS require, then AMD, and if it doesn't find either of those, it runs this code. It tries to attach the `6to5` function to `window`, `global`, and `self` (in that order).

In Node.js, (ExecJS's [4th choice for JS runtime](https://github.com/sstephenson/execjs/blob/master/lib/execjs/runtimes.rb#L76) which is installed on all Travis CI machines), `global` is always available. In this case, 6to5 happily sets `.to5` on the `global` object, and the gem works.

However, in *therubyracer* (ExecJS's [1st choice for JS runtime](https://github.com/sstephenson/execjs/blob/master/lib/execjs/runtimes.rb#L73)) and *JavaScriptCore* (ExecJS's [2nd choice for JS runtime](https://github.com/sstephenson/execjs/blob/master/lib/execjs/runtimes.rb#L75), `window`, `global`, and `self` are all undefined. Resulting in the error here.

**Solution**

Set `self` to `this` so that `6to5.js` will attach and evaluate properly.

Add explicit tests for rubyracer, but test as many runtimes as possible for errors